### PR TITLE
Add GPU-optimized gram eigendecomposition backend + fix float64 performance issue

### DIFF
--- a/tests/benchmark_gram.py
+++ b/tests/benchmark_gram.py
@@ -1,0 +1,145 @@
+"""Benchmark and numerical comparison of SVD backends for IncrementalPCA.
+
+Compares three backends (full SVD, low-rank SVD, gram eigendecomp) on:
+  1. Wall-clock time for partial_fit
+  2. Raw SVD-only time (isolating from partial_fit overhead)
+  3. Numerical similarity of learned components
+
+Usage:
+    python tests/benchmark_gram.py
+
+Requires a CUDA GPU.
+"""
+
+import time
+
+import torch
+
+from torch_incremental_pca import IncrementalPCA
+
+
+def component_similarity(components_a, components_b):
+    """Mean absolute cosine similarity between two sets of components."""
+    a = components_a / components_a.norm(dim=1, keepdim=True)
+    b = components_b / components_b.norm(dim=1, keepdim=True)
+    return torch.abs((a * b).sum(dim=1)).mean().item()
+
+
+def subspace_similarity(components_a, components_b):
+    """Subspace overlap via singular values of the projection matrix. 1.0 = identical."""
+    k = components_a.shape[0]
+    overlap = components_a @ components_b.T
+    return (torch.linalg.svdvals(overlap).sum() / k).item()
+
+
+def main():
+    assert torch.cuda.is_available(), "This benchmark requires a CUDA GPU."
+    device = "cuda"
+
+    n_features = 2000
+    n_components = 100
+    batch_size = 500
+    n_reps = 100
+
+    print(f"Benchmark: D={n_features}, K={n_components}, batch_size={batch_size}")
+    m = n_components + batch_size + 1
+    print(f"Augmented matrix shape: ({m}, {n_features})")
+    print()
+
+    # Create true components and synthetic data
+    torch.manual_seed(42)
+    true_components = torch.randn(n_components, n_features, device=device)
+    true_components = torch.linalg.qr(true_components.T).Q.T
+    strengths = torch.logspace(1, -1, n_components, device=device)
+
+    # Pre-generate all batches (not timed)
+    torch.manual_seed(123)
+    batches = []
+    for _ in range(n_reps):
+        coeffs = torch.randn(batch_size, n_components, device=device)
+        signal = (coeffs * strengths) @ true_components
+        noise = torch.randn(batch_size, n_features, device=device) * 0.1
+        batches.append(signal + noise)
+
+    # --- partial_fit benchmark ---
+    print("=== partial_fit benchmark ===")
+    methods = {
+        "full": lambda: IncrementalPCA(n_components=n_components, copy=True),
+        "gram": lambda: IncrementalPCA(n_components=n_components, copy=True, gram=True),
+        "lowrank": lambda: IncrementalPCA(n_components=n_components, copy=True, lowrank=True),
+    }
+
+    results = {}
+    for name, make_ipca in methods.items():
+        # Warmup (3 batches, not timed)
+        ipca_warmup = make_ipca()
+        for i in range(3):
+            ipca_warmup.partial_fit(batches[i])
+        torch.cuda.synchronize()
+
+        # Timed run
+        ipca = make_ipca()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for batch in batches:
+            ipca.partial_fit(batch)
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - t0
+
+        results[name] = {"model": ipca, "time": elapsed}
+        print(f"{name:>8}: {elapsed:.3f}s")
+
+    print()
+    full_time = results["full"]["time"]
+    for name in ["gram", "lowrank"]:
+        speedup = full_time / results[name]["time"]
+        print(f"{name:>8} speedup vs full: {speedup:.2f}x")
+
+    # --- Raw SVD-only benchmark ---
+    print("\n=== Raw SVD-only benchmark ===")
+    ipca_full = IncrementalPCA(n_components=n_components)
+    ipca_gram = IncrementalPCA(n_components=n_components, gram=True)
+    X_test = torch.randn(m, n_features, device=device)
+
+    # Warmup
+    for _ in range(5):
+        ipca_full._svd_fn_full(X_test.clone())
+        ipca_gram._svd_fn_gram(X_test.clone())
+    torch.cuda.synchronize()
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n_reps):
+        ipca_full._svd_fn_full(X_test.clone())
+    torch.cuda.synchronize()
+    t_full = time.perf_counter() - t0
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n_reps):
+        ipca_gram._svd_fn_gram(X_test.clone())
+    torch.cuda.synchronize()
+    t_gram = time.perf_counter() - t0
+
+    print(f"    full SVD: {t_full:.3f}s ({n_reps} calls)")
+    print(f"  gram eigh: {t_gram:.3f}s ({n_reps} calls)")
+    print(f"  gram speedup: {t_full / t_gram:.2f}x")
+
+    # --- Numerical comparison ---
+    print("\n=== Numerical similarity ===")
+    ref = results["full"]["model"].components_
+    print("vs full SVD (mean |cosine|):")
+    for name in ["gram", "lowrank"]:
+        sim = component_similarity(ref, results[name]["model"].components_)
+        sub = subspace_similarity(ref, results[name]["model"].components_)
+        print(f"  {name:>8}: cosine={sim:.6f}, subspace={sub:.6f}")
+
+    print("vs true components:")
+    for name in ["full", "gram", "lowrank"]:
+        sim = component_similarity(true_components, results[name]["model"].components_)
+        sub = subspace_similarity(true_components, results[name]["model"].components_)
+        print(f"  {name:>8}: cosine={sim:.6f}, subspace={sub:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,63 @@
+"""Regression test: verify new implementation matches old for float64 inputs.
+
+Ensures that the float64 fix in _incremental_mean_and_var doesn't change
+results when the input is already float64 (where no dtype casting occurs).
+"""
+
+import torch
+
+from torch_incremental_pca import IncrementalPCA
+from torch_incremental_pca.old_incremental_pca import IncrementalPCA as OldIncrementalPCA
+
+
+def test_float64_regression():
+    """New implementation with float64 input should match old implementation exactly."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    n_features = 200
+    n_components = 20
+    batch_size = 50
+    n_batches = 10
+
+    # Generate deterministic data
+    torch.manual_seed(42)
+    batches = [torch.randn(batch_size, n_features, device=device, dtype=torch.float64)
+               for _ in range(n_batches)]
+
+    old_ipca = OldIncrementalPCA(n_components=n_components, copy=True)
+    new_ipca = IncrementalPCA(n_components=n_components, copy=True)
+
+    for batch in batches:
+        old_ipca.partial_fit(batch)
+        new_ipca.partial_fit(batch)
+
+    # Mean should be identical (both compute in float64, new casts back to input dtype which is float64)
+    mean_diff = (old_ipca.mean_ - new_ipca.mean_).abs().max().item()
+    print(f"Mean max diff: {mean_diff:.2e}")
+    assert mean_diff < 1e-10, f"Mean mismatch: {mean_diff}"
+
+    # Variance
+    var_diff = (old_ipca.var_ - new_ipca.var_).abs().max().item()
+    print(f"Var max diff: {var_diff:.2e}")
+    assert var_diff < 1e-10, f"Variance mismatch: {var_diff}"
+
+    # Components (compare via cosine similarity since sign can flip)
+    cos_sim = torch.abs((old_ipca.components_ * new_ipca.components_).sum(dim=1))
+    min_cos = cos_sim.min().item()
+    print(f"Components min |cosine|: {min_cos:.10f}")
+    assert min_cos > 0.9999, f"Component mismatch: min cosine = {min_cos}"
+
+    # Singular values
+    sv_diff = (old_ipca.singular_values_ - new_ipca.singular_values_).abs().max().item()
+    print(f"Singular values max diff: {sv_diff:.2e}")
+    assert sv_diff < 1e-6, f"Singular value mismatch: {sv_diff}"
+
+    # Explained variance
+    ev_diff = (old_ipca.explained_variance_ - new_ipca.explained_variance_).abs().max().item()
+    print(f"Explained variance max diff: {ev_diff:.2e}")
+    assert ev_diff < 1e-6, f"Explained variance mismatch: {ev_diff}"
+
+    print("\nAll regression tests passed!")
+
+
+if __name__ == "__main__":
+    test_float64_regression()

--- a/torch_incremental_pca/incremental_pca.py
+++ b/torch_incremental_pca/incremental_pca.py
@@ -11,6 +11,20 @@ class IncrementalPCA:
     This class provides methods to fit the model on data incrementally in batches, and to transform new data based on
     the principal components learned during the fitting process.
 
+    Three SVD backends are available, selectable via the `lowrank` and `gram` flags:
+
+    - **Full SVD** (default): Uses `torch.linalg.svd`. Exact but uses Householder
+      bidiagonalization which is inherently sequential and underutilizes GPU parallelism.
+    - **Low-rank SVD** (`lowrank=True`): Uses `torch.svd_lowrank` (randomized SVD).
+      Faster for very large matrices where `n_components << min(n_samples, n_features)`,
+      but involves multiple power iterations that can be slower for moderate-sized matrices.
+    - **Gram eigendecomposition** (`gram=True`): Computes `G = X @ X.T` (a GEMM) then
+      `torch.linalg.eigh(G)` to recover singular values/vectors. Mathematically equivalent
+      to full SVD but significantly faster on GPU because it replaces sequential Householder
+      reflections with highly-parallelizable matrix multiplications. Recommended when the
+      augmented matrix is wide (rows < cols), which is the typical case in incremental PCA
+      when `n_components + batch_size < n_features`.
+
     Args:
         n_components (int, optional): Number of components to keep. If `None`, it's set to the minimum of the
             number of samples and features. Defaults to None.
@@ -21,12 +35,19 @@ class IncrementalPCA:
             argument only works on CUDA inputs. Available options are: None, gesvd, gesvdj, and gesvda. Defaults to
             None.
         lowrank (bool, optional): Whether to use torch.svd_lowrank instead of torch.linalg.svd which can be faster.
-            Defaults to False.
+            Mutually exclusive with `gram`. Defaults to False.
         lowrank_q (int, optional): For an adequate approximation of n_components, this parameter defaults to
             n_components * 2.
         lowrank_niter (int, optional): Number of subspace iterations to conduct for torch.svd_lowrank.
             Defaults to 4.
         lowrank_seed (int, optional): Seed for making results of torch.svd_lowrank reproducible.
+        gram (bool, optional): Whether to use gram-matrix eigendecomposition instead of
+            torch.linalg.svd. For wide matrices (rows < cols), this computes G = X @ X.T
+            followed by torch.linalg.eigh(G) and recovers singular vectors via
+            Vt = U.T @ X / S. Mathematically equivalent to full SVD but significantly faster
+            on GPU because it uses GEMM operations instead of sequential Householder
+            reflections. Falls back to full SVD when the matrix is tall (rows > cols).
+            Mutually exclusive with `lowrank`. Defaults to False.
     """
 
     def __init__(
@@ -39,6 +60,7 @@ class IncrementalPCA:
         lowrank_q: Optional[int] = None,
         lowrank_niter: int = 4,
         lowrank_seed: Optional[int] = None,
+        gram: bool = False,
     ):
         self.n_components = n_components
         self.copy = copy
@@ -48,8 +70,12 @@ class IncrementalPCA:
         self.lowrank_q = lowrank_q
         self.lowrank_niter = lowrank_niter
         self.lowrank_seed = lowrank_seed
+        self.gram = gram
 
         self.n_features_ = None
+
+        if self.lowrank and self.gram:
+            raise ValueError("lowrank and gram are mutually exclusive. Set only one to True.")
 
         if self.lowrank:
             self._validate_lowrank_params()
@@ -72,6 +98,44 @@ class IncrementalPCA:
                 torch.manual_seed(self.lowrank_seed)
             U, S, V = torch.svd_lowrank(X, q=self.lowrank_q, niter=self.lowrank_niter)
             return U, S, V.mH
+
+    def _svd_fn_gram(self, X):
+        """Compute SVD via gram-matrix eigendecomposition.
+
+        For wide matrices (m < D), instead of running the sequential Householder
+        bidiagonalization used by torch.linalg.svd, this method computes the
+        small gram matrix G = X @ X.T (shape (m, m)) using a single GEMM,
+        then finds its eigendecomposition via torch.linalg.eigh. The right
+        singular vectors are recovered as Vt = diag(1/S) @ U.T @ X, which is
+        another GEMM.
+
+        This is mathematically equivalent to full SVD but significantly faster on
+        GPU because GEMM operations achieve much higher hardware utilization than
+        the sequential Householder reflections used by torch.linalg.svd.
+
+        Falls back to full SVD when the matrix is tall (m > D).
+
+        Args:
+            X (torch.Tensor): Input matrix of shape (m, D).
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: (U, S, Vt) where
+                U is (m, m), S is (m,), Vt is (m, D).
+        """
+        m, D = X.shape
+        if m > D:
+            return self._svd_fn_full(X)
+        G = X @ X.mT  # (m, m) — GEMM
+        evals, evecs = torch.linalg.eigh(G)  # ascending order
+        # Flip to descending order (largest eigenvalues first)
+        evals = evals.flip(0)
+        evecs = evecs.flip(1)
+        S = torch.sqrt(evals.clamp(min=0))
+        # Recover right singular vectors: Vt = diag(1/S) @ U.T @ X
+        valid = S > 1e-7
+        Vt = torch.zeros(m, D, dtype=X.dtype, device=X.device)
+        Vt[valid] = (evecs[:, valid].mT @ X) / S[valid].unsqueeze(1)
+        return evecs, S, Vt
 
     def _validate_data(self, X) -> torch.Tensor:
         """
@@ -115,6 +179,12 @@ class IncrementalPCA:
         """
         Computes the incremental mean and variance for the data `X`.
 
+        Uses float64 internally for numerical stability when accumulating sums,
+        matching the behavior of scikit-learn's implementation. The results are
+        cast back to the input dtype before returning to avoid propagating float64
+        into downstream computations (e.g., SVD), which would significantly hurt
+        GPU performance.
+
         Args:
             X (torch.Tensor): The batch input data tensor with shape (n_samples, n_features).
             last_mean (torch.Tensor): The previous mean tensor with shape (n_features,).
@@ -133,13 +203,15 @@ class IncrementalPCA:
             if last_variance is None:
                 raise ValueError("last_variance should not be None if last_sample_count > 0.")
 
+        input_dtype = X.dtype
+
         new_sample_count = torch.tensor([X.shape[0]], device=X.device)
         updated_sample_count = last_sample_count + new_sample_count
 
         if last_mean is None:
             last_sum = torch.zeros(X.shape[1], dtype=torch.float64, device=X.device)
         else:
-            last_sum = last_mean * last_sample_count
+            last_sum = last_mean.double() * last_sample_count
 
         new_sum = X.sum(dim=0, dtype=torch.float64)
 
@@ -154,7 +226,7 @@ class IncrementalPCA:
         if last_variance is None:
             updated_variance = new_unnormalized_variance / updated_sample_count
         else:
-            last_unnormalized_variance = last_variance * last_sample_count
+            last_unnormalized_variance = last_variance.double() * last_sample_count
             last_over_new_count = last_sample_count.double() / new_sample_count
             updated_unnormalized_variance = (
                 last_unnormalized_variance
@@ -163,7 +235,10 @@ class IncrementalPCA:
             )
             updated_variance = updated_unnormalized_variance / updated_sample_count
 
-        return updated_mean, updated_variance, updated_sample_count
+        # Cast back to input dtype to avoid float64 propagating into SVD/eigendecomp,
+        # which would severely hurt GPU performance (float64 throughput is up to 32x
+        # lower than float32 on consumer GPUs).
+        return updated_mean.to(input_dtype), updated_variance.to(input_dtype), updated_sample_count
 
     @staticmethod
     def _svd_flip(u, v, u_based_decision=True) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -253,7 +328,7 @@ class IncrementalPCA:
         else:
             col_batch_mean = torch.mean(X, dim=0)
             X -= col_batch_mean
-            mean_correction_factor = torch.sqrt((self.n_samples_seen_.double() / n_total_samples) * n_samples)
+            mean_correction_factor = torch.sqrt((self.n_samples_seen_.to(X.dtype) / n_total_samples) * n_samples)
             mean_correction = mean_correction_factor * (self.mean_ - col_batch_mean)
             X = torch.vstack(
                 (
@@ -265,6 +340,8 @@ class IncrementalPCA:
 
         if self.lowrank:
             U, S, Vt = self._svd_fn_lowrank(X)
+        elif self.gram:
+            U, S, Vt = self._svd_fn_gram(X)
         else:
             U, S, Vt = self._svd_fn_full(X)
         U, Vt = self._svd_flip(U, Vt, u_based_decision=False)
@@ -297,7 +374,7 @@ class IncrementalPCA:
             torch.Tensor: Transformed data tensor with shape (n_samples, n_components).
         """
         X = X - self.mean_
-        return torch.mm(X.double(), self.components_.T).to(X.dtype)
+        return torch.mm(X, self.components_.T)
 
     @staticmethod
     def gen_batches(n: int, batch_size: int, min_batch_size: int = 0):


### PR DESCRIPTION
First of all, very nice library! I had some efficiency problem when running on GPU, so I made this fix.

### Summary
- Add `gram=True` SVD backend that uses gram-matrix eigendecomposition instead of `torch.linalg.svd`, up to **5x faster on GPU**
- Fix float64 dtype leak from `_incremental_mean_and_var` that causes all downstream computation to run in float64

### Problem

Two GPU performance issues:

1. **float64 leak**: `_incremental_mean_and_var` computes in float64 for numerical stability (matching sklearn), but the float64 result propagates into the augmented matrix used for SVD. On consumer GPUs, float64 throughput is up to 32x lower than float32, causing significant slowdowns.

2. **SVD is GPU-unfriendly**: `torch.linalg.svd` uses many sequential operations. This severely underutilizes GPU parallelism, especially as the augmented matrix grows (more rows = more sequential steps). (

### Solution

**Gram eigendecomposition** (`gram=True`): For a wide matrix X of shape (m, D) where m < D, instead of SVD:
1. `G = X @ X.T` — shape (m, m), a single GEMM (the most optimized GPU operation)
2. `eigh(G)` — eigendecompose the small gram matrix
3. `Vt = U.T @ X / S` — recover right singular vectors, another GEMM

This is mathematically equivalent to full SVD but replaces m sequential Householder reflections with two highly-parallelizable GEMM calls. Falls back to full SVD when the matrix is tall (rows > cols).

**float64 fix**: `_incremental_mean_and_var` still computes in float64 internally (preserving numerical stability), but casts results back to the input dtype before returning. This prevents float64 from leaking into SVD/eigendecomp.

### Benchmark (RTX A4500)

```
Benchmark: D=2000, K=100, batch_size=500
Augmented matrix shape: (601, 2000)

=== partial_fit benchmark ===
    full: 4.011s
    gram: 0.874s
 lowrank: 2.055s

    gram speedup vs full: 4.59x
 lowrank speedup vs full: 1.95x

=== Numerical similarity ===
vs full SVD (mean |cosine|):
      gram: cosine=0.999992, subspace=0.999964
   lowrank: cosine=0.996125, subspace=0.999402
```

Gram is nearly exact (cosine > 0.9999) while being ~5x faster. Low-rank is less accurate (0.996) and only ~2x faster.

### Usage

```python
ipca = IncrementalPCA(n_components=100, gram=True)
for batch in data_batches:
    ipca.partial_fit(batch)
```

### Changes
- `incremental_pca.py`: Added `gram` parameter, `_svd_fn_gram` method, float64 fix in `_incremental_mean_and_var`
- `tests/benchmark_gram.py`: Benchmark script comparing all three backends
- `tests/test_regression.py`: Regression test verifying float64 inputs produce identical results (mean, variance, components, singular values) to the original implementation

