### PR TITLE
Regularize the gram matrix before computing eigh

### DIFF
--- a/torch_incremental_pca/incremental_pca.py
+++ b/torch_incremental_pca/incremental_pca.py
@@ -212,6 +212,7 @@ class IncrementalPCA:
 
         # G is (m, m)
         G = X @ X.mT
+        G += self.gram_eps * torch.eye(m, device=G.device, dtype=G.dtype)
         evals, evecs = torch.linalg.eigh(G)  # ascending
 
         # Take largest-k (from the end) then flip just those to descending
@@ -220,7 +221,7 @@ class IncrementalPCA:
 
         S_k = torch.sqrt(evals_k.clamp(min=0))
 
-        invS = (S_k.clamp(min=self.gram_eps)).reciprocal()  # (k,)
+        invS = S_k.reciprocal()  # (k,)
 
         # Fuse scaling into small factor (k x m) then GEMM to get (k x D)
         # Vt_k = diag(1/S) @ U^T @ X


### PR DESCRIPTION
## Gram matrix regularization for `eigh` stability

### Problem

I noticed that when using `IncrementalPCA(gram=True)`, the Gram matrix `G = X @ X.T` passed to `torch.linalg.eigh` can be ill-conditioned, causing `eigh` to fail with:

```
torch._C._LinAlgError: linalg.eigh: The algorithm failed to converge because the
input matrix is ill-conditioned or has too many repeated eigenvalues
```

### Fix

Added regularization to `_svd_fn_gram`: after computing `G = X @ X.T`, we add `εI` to bound the minimum eigenvalue away from zero:

```python
G += self.gram_eps * torch.eye(m, device=G.device, dtype=G.dtype)
```

Previously there also was some regularization, but it was done after eigh, so I moved it.